### PR TITLE
fix krb5 dependencies

### DIFF
--- a/Formula/krb5.rb
+++ b/Formula/krb5.rb
@@ -24,6 +24,7 @@ class Krb5 < Formula
   depends_on "openssl@1.1"
 
   uses_from_macos "bison"
+  uses_from_macos "libedit"
 
   def install
     cd "src" do

--- a/Formula/krb5.rb
+++ b/Formula/krb5.rb
@@ -1,8 +1,8 @@
 class Krb5 < Formula
   desc "Network authentication protocol"
   homepage "https://web.mit.edu/kerberos/"
-  url "https://kerberos.org/dist/krb5/1.20/krb5-1.20.tar.gz"
-  sha256 "7e022bdd3c851830173f9faaa006a230a0e0fdad4c953e85bff4bf0da036e12f"
+  url "https://kerberos.org/dist/krb5/1.20/krb5-1.20.1.tar.gz"
+  sha256 "704aed49b19eb5a7178b34b2873620ec299db08752d6a8574f95d41879ab8851"
   license :cannot_represent
 
   livecheck do


### PR DESCRIPTION
Building krb5 requires libedit for the header editline/readline.h. krb5 builds fine on debian for some reason but it doesn't build on other linux distros that don't have the header file somewhere. In any case, including libedit should be safer.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
